### PR TITLE
Added missing return type to inappupdate_bytes_downladed()

### DIFF
--- a/docs/InAppUpdate.js
+++ b/docs/InAppUpdate.js
@@ -111,6 +111,8 @@ function inappupdate_install_status() {}
 /**
  * @func inappupdate_bytes_downloaded
  * @desc Returns the number of bytes downloaded so far.
+ * 
+ * @returns {real}
  * @func_end
  */
 function inappupdate_bytes_downloaded() {}


### PR DESCRIPTION
This PR contains a small change to the documentation related to:

* YoYoGames/GMEXT-InAppUpdate#3

The wiki has already been updated with the changes.